### PR TITLE
fix(scanner): remove erroneous await on synchronous get_batch_metrics()

### DIFF
--- a/src/github_ioc_scanner/scanner.py
+++ b/src/github_ioc_scanner/scanner.py
@@ -571,7 +571,7 @@ class GitHubIOCScanner:
                 )
                 
                 # Get batch metrics for additional insights
-                batch_metrics = await self.batch_coordinator.get_batch_metrics()
+                batch_metrics = self.batch_coordinator.get_batch_metrics()
                 logger.info(f"Batch scan completed: {len(all_matches)} matches, "
                           f"{batch_metrics.cache_hit_rate:.1f}% cache hit rate, "
                           f"{batch_metrics.parallel_efficiency:.2f} parallel efficiency")
@@ -1973,7 +1973,7 @@ class GitHubIOCScanner:
                 successful_repos = len([repo for repo, matches in batch_results['processing_results'].items() if matches])
                 
                 # Get comprehensive metrics
-                batch_metrics = await self.batch_coordinator.get_batch_metrics()
+                batch_metrics = self.batch_coordinator.get_batch_metrics()
                 
                 # Log comprehensive performance information
                 log_performance(


### PR DESCRIPTION
## Problem

The `get_batch_metrics()` method in `batch_coordinator.py` is defined as a regular synchronous method (`def`), but it was being `await`-ed in two places in `scanner.py` (lines 574 and 1976).

This caused a `TypeError: object BatchMetrics can't be used in 'await' expression` at runtime. The error was silently caught by surrounding `try/except` blocks, which caused the scanner to fall back to sequential (slow) processing for every scan — the batch processing feature (intended to be the fast path) never actually worked in production.

Closes #7

## Analysis

**Root cause:**
- `BatchCoordinator.get_batch_metrics()` is declared as `def get_batch_metrics(self) -> BatchMetrics:` (synchronous)
- But in `scanner.py`, it was called with `await self.batch_coordinator.get_batch_metrics()`

**Impact:**
- High — every scan silently degrades to sequential mode regardless of configuration
- Batch processing (the performance-optimized path) has never worked due to this bug

## Solution

Remove the `await` keyword at the two call sites in `scanner.py`:
- Line 574: batch scan completion logging
- Line 1976: end-to-end batch scan metrics

This is the minimal, safe fix. The method performs no I/O — it only computes metrics from in-memory state — so it doesn't need to be async.

## Verification

- [x] Code compiles without errors
- [x] All `batch_coordinator` tests pass (45 tests)
- [x] Manual verification that `get_batch_metrics()` returns a synchronous `BatchMetrics` object

## Notes

Alternative considered: changing `get_batch_metrics` to `async def`. Rejected because:
1. The method performs no I/O operations
2. Making it async would be a larger change with no benefit
3. The synchronous approach is simpler and more efficient